### PR TITLE
Include top level python files when installing for KernelBench

### DIFF
--- a/KernelBench/pyproject.toml
+++ b/KernelBench/pyproject.toml
@@ -3,9 +3,6 @@
 requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools]
-find = {}
-
 [project]
 name = "kernelbench-local"
 version = "0.0.1"
@@ -35,6 +32,9 @@ dependencies = [
 build = [
   "psutil>=5",
 ]
+
+[tool.setuptools]
+py-modules = []
 
 [tool.uv]
 # No special sources by default for KernelBench.

--- a/KernelBench/pyproject.toml
+++ b/KernelBench/pyproject.toml
@@ -3,6 +3,9 @@
 requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools]
+find = {}
+
 [project]
 name = "kernelbench-local"
 version = "0.0.1"


### PR DESCRIPTION
The top level python files `KernelBench/cuda_eval_client.py`, `KernelBench/cuda_eval_server.py`, etc. would throw an error when running the installation script.